### PR TITLE
Fix printing identities

### DIFF
--- a/git-identity
+++ b/git-identity
@@ -13,7 +13,7 @@ lookup () {
   local identity="$1"
   local key="$2"
 
-  git config -z "identity.$identity.$key"
+  git config "identity.$identity.$key"
 }
 
 format_identity () {


### PR DESCRIPTION
`-z` will include null bytes in the output, which is good for parsing by
scripts, but bad for dumping into terminals.

I get this error which this commit fixes:

    git-identity: line 27: warning: command substitution: ignored null byte in input