### PR TITLE
Support for GPG keys in identities

### DIFF
--- a/GPG_SETUP.md
+++ b/GPG_SETUP.md
@@ -1,0 +1,54 @@
+Setting up GPG for Git
+======================
+
+If you want to use the GPG feature within `git`, there are a few steps for you to follow. These steps are described at many places, but a reminder never hurts.
+
+Generating a new key
+--------------------
+
+If you don't have any GPG key yet, you can generate it from a terminal (or Git Bash for Windows) using the following command:
+
+    $ gpg --gen-key
+	
+Follow the wizard and answer the questions about your identity (name, email address). It's advised to leave the default values, but if you wish extra security, chose a keysize of 4096.
+Once generated, you can export your keys via the following commands:
+
+    $ gpg --export --armor user@example.com > public.asc
+	$ gpg --export-secret-keys -o private.gpg user@example.com
+	$ gpg --output revokecert.asc --gen-revoke user@example.com
+
+This will output three different files:
+
+* `public.asc` contains your public key. Copy its content and [send it to GitHub](https://help.github.com/articles/adding-a-new-gpg-key-to-your-github-account/) or any other git service you use
+* `private.gpg` contains your private key. This one needs to be put on a safe place. You must **avoid publishing somewhere at all cost**
+* `revokecert.asc` contains a certification for revoking your keys. Simply put, you'll need it only if your keys gets compromised
+	
+Importing an existing key
+-------------------------
+
+If you already have a GPG key that you wish to use for signing your commits, you must first import it to your system (if it's not present).
+
+Check which keys you already have:
+
+    $ gpg --list-secret-keys
+
+If your key is not in there, you can import it:
+
+    $ gpg --import myprivatekey.gpg
+	
+Check it has been imported:
+
+    $ gpg --list-secret-keys --keyid-format LONG
+	
+Copy the ID of your private key and register this key in `git-identity`:
+
+    $ git identity --define-gpg <identity name> <gpgkeyid>
+
+Additional resources
+--------------------
+
+Here are some interesting resources you might want to read if you wish to go deeper on GPG with git:
+
+* [Generating a new GPG key](https://help.github.com/articles/generating-a-new-gpg-key/)
+* [Adding a new GPG key to your GitHub account](https://help.github.com/articles/adding-a-new-gpg-key-to-your-github-account/)
+* [Installing your GPG key in git](https://help.github.com/articles/telling-git-about-your-gpg-key/)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ will pick it up and make it available as `git identity`.
 
     $ ln -s git-identity ~/bin/git-identity
 
-Then you may setup a default identity with the following command (see Usage for
-more information):
+Under Windows, go to System > Advanced System Parameters > Environment Variable. Find the "Path" entry under *system variables* and add the path to where you downloaded `git-identity`.
+
+Then you may setup a default identity with the following command (see Usage for more information):
 
     $ git identity --define default Me me@example.org
 
@@ -29,6 +30,15 @@ To get zsh completion, move the `git-identity.zsh-completion` file to a location
 Usage
 -----
 
+Add an identity:
+
+    $ git identity --define <identity name> <user name> <user email>
+
+Add a GPG key to the identity (see GPG specific information below)
+
+	$ git identity --define-gpg <identity name> <gpgkeyid>
+	Added GPG key DA221397A6FF5EZZ to [default] user <user@example.org> (GPG key: DA221397A6FF5EZZ)
+
 Print the current identity:
 
     $ git identity
@@ -39,7 +49,7 @@ Change identity:
     $ git identity user2
     Using identity: [default2] user2 <user2@example.org>
 
-Listing identities:
+List all identities:
 
     $ git identity --list
     Available identities:
@@ -52,10 +62,6 @@ Listing raw identities:
     default
     default2
 
-Adding an identity:
-
-    $ git identity --define <identity name> <user name> <user email>
-
 Deleting an identity:
 
     $ git identity --remove <identity name>
@@ -65,3 +71,7 @@ Printing the raw identity (for use in scripts)
     $ git identity --print
     $ git identity --print <identity name>
 
+Setting up GPG
+--------------
+
+More information about how to use GPG with `git-identity` may be found in [GPG_SETUP.md](GPG_SETUP.md)

--- a/git-identity
+++ b/git-identity
@@ -42,19 +42,25 @@ use_identity () {
   local email="$(lookup "$identity" email)"
   local gpgkey="$(lookup "$identity" signingkey)"
 
-  echo "Using identity: $(format_identity "$identity")"
-  git config user.identity "$identity"
-  git config user.name "$name"
-  git config user.email "$email"
-  
-  # Enable or disable GPG key usage
-  if [ "$gpgkey" != "" -a "$gpgkey" != " " ];
+  if [ "$name" != "" -a "$name" != " " ]
   then
-    git config user.signingkey "$gpgkey"
-    git config commit.gpgsign true
+    echo "Using identity: $(format_identity "$identity")"
+    git config user.identity "$identity"
+    git config user.name "$name"
+    git config user.email "$email"
+  
+    # Enable or disable GPG key usage
+    if [ "$gpgkey" != "" -a "$gpgkey" != " " ];
+    then
+      git config user.signingkey "$gpgkey"
+	  git config commit.gpgsign true
+    else
+      git config --unset user.signingkey
+      git config --unset commit.gpgsign
+    fi
   else
-    git config --unset user.signingkey
-    git config --unset commit.gpgsign
+    echo "Identity $identity does not exist. Doing nothing..."
+	echo "$(print_current_identity)"
   fi
 }
 
@@ -84,7 +90,12 @@ print_raw_identity () {
 print_current_identity () {
   local identity="$(git config user.identity)"
 
-  echo "Current identity: $(format_identity "$identity")"
+  if [ "$identity" != "" -a "$identity" != " " ]
+  then
+    echo "Current identity: $(format_identity "$identity")"
+  else
+    echo "Current identity: no identity set"
+  fi
 }
 
 define_identity () {
@@ -95,6 +106,7 @@ define_identity () {
   git config --global identity."$identity".name "$name"
   git config --global identity."$identity".email "$email"
   echo "Created $(format_identity "$identity")"
+  echo "Enter 'git identity $identity' to use it in the current repository."
 }
 
 remove_identity () {

--- a/git-identity
+++ b/git-identity
@@ -5,6 +5,7 @@ USAGE="$USAGE | [-p|--print] <identity>"
 USAGE="$USAGE | [-r|--remove] <identity>"
 USAGE="$USAGE | [-l|--list]"
 USAGE="$USAGE | [-R|--list-raw]"
+USAGE="$USAGE | [--define-gpg] <gpgkeyid>"
 USAGE="$USAGE | <identity>"
 
 . $(git --exec-path)/git-sh-setup
@@ -24,19 +25,37 @@ format_identity () {
 
 format_raw_identity () {
   local identity="$1"
-
-  echo "$(lookup "$identity" name) <$(lookup "$identity" email)>"
+  local gpgkey="$(lookup $identity signingkey)"
+  
+  local output="$(lookup "$identity" name) <$(lookup "$identity" email)>"
+  if [ "$gpgkey" != "" -a "$gpgkey" != " " ];
+  then
+    output="$output (GPG key: $gpgkey)"
+  fi
+  
+  echo "$output"
 }
 
 use_identity () {
   local identity="$1"
   local name="$(lookup "$identity" name)"
   local email="$(lookup "$identity" email)"
+  local gpgkey="$(lookup "$identity" signingkey)"
 
   echo "Using identity: $(format_identity "$identity")"
   git config user.identity "$identity"
   git config user.name "$name"
   git config user.email "$email"
+  
+  # Enable or disable GPG key usage
+  if [ "$gpgkey" != "" -a "$gpgkey" != " " ];
+  then
+    git config user.signingkey "$gpgkey"
+    git config commit.gpgsign true
+  else
+    git config --unset user.signingkey
+    git config --unset commit.gpgsign
+  fi
 }
 
 list_raw_identities () {
@@ -86,6 +105,15 @@ remove_identity () {
   echo "Removed $formated_identity"
 }
 
+define_gpg () {
+  local identity="$1"
+  local gpgkey="$2"
+  
+  git config --global identity."$identity".signingkey "$gpgkey"
+  git config --global identity."$identity".gpgsign true
+  echo "Added GPG key $gpgkey to $(format_identity "$identity")"
+}
+
 IDENTITY="$1"
 
 check_arguments () {
@@ -108,6 +136,12 @@ case $IDENTITY in
     define_identity "$1" "$2" "$3"
     ;;
 
+  --define-gpg)
+    shift
+	check_arguments $# 2
+	define_gpg "$1" "$2"
+	;;
+	
   -r|--remove)
     shift
     check_arguments $# 1
@@ -118,6 +152,6 @@ case $IDENTITY in
     shift
     print_raw_identity "$1"
     ;;
-
+  
   *) use_identity "$IDENTITY" ;;
 esac

--- a/git-identity
+++ b/git-identity
@@ -120,10 +120,18 @@ remove_identity () {
 define_gpg () {
   local identity="$1"
   local gpgkey="$2"
+  local name="$(lookup "$identity" name)"
   
-  git config --global identity."$identity".signingkey "$gpgkey"
-  git config --global identity."$identity".gpgsign true
-  echo "Added GPG key $gpgkey to $(format_identity "$identity")"
+  if [ "$name" != "" -a "$name" != " " ]
+  then
+    git config --global identity."$identity".signingkey "$gpgkey"
+    git config --global identity."$identity".gpgsign true
+    echo "Added GPG key $gpgkey to $(format_identity "$identity")"
+  
+    use_identity "$identity"
+  else
+    echo "Error: could not define GPG key for undefined identity '$identity'"
+  fi
 }
 
 IDENTITY="$1"


### PR DESCRIPTION
Hi madx,

First, thank you very much for that simplistic yet awesome git plugin. I've been looking for such a solution since ages and you came with an incredibly efficient idea. I however thought it could benefit from GPG key integration for commit verification. So I added it and... here's my modest contribution if you're willing to integrate it to your project!

My modifications are:

* Integration of GPG keys via `git identity --define-gpg` for those who would like to sign their commits
* Documentation related to its usage + minor enhancements to the README
* Additional conditions to avoid triggering things that could lead to errors/inconsistencies:
  * `git identity <identity name>` isn't triggered if the identity is not defined
  * `git identity --define-gpg <identity name> <gpgkey>` isn't triggered if the identity is not defined
  * `git identity` returns the current identity if it exists; otherwise a messages says no identity is selected
* When run, `git identity --define-gpg` runs again the `git identity <identity name>` command to ensure the local repository is updated accordingly

Currently there's no support for removing/disabling a GPG key since I didn't quite see the use case there, but it could be implemented pretty easily.

Hope you'll find my update interesting, and thanks again to all contributors of this plugin!