### PR TITLE
Add basher package file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ in your initialization scripts, such as `.bashrc`.
 
 To get zsh completion, move the `git-identity.zsh-completion` file to a location present in your `$FPATH`, renaming the file to `_git-identity`.
 
+You can also use [basher](https://github.com/basherpm/basher) to install git-identity:
+
+    $ basher install madx/git-identity
+
 Usage
 -----
 

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,8 @@
+##
+# Basher package file
+
+BINS='git-identity'
+
+BASH_COMPLETIONS='git-identity.bash-completion'
+
+ZSH_COMPLETIONS='git-identity.zsh-completion'


### PR DESCRIPTION
This small file will let users install git-identity with [basher](https://github.com/basherpm/basher), which will seamlessly add git-identity to the users PATH, automatically add completions to the users environment, and provide the user with an easy way to update to the latest version.

I know basher is not very widely used, but for the people who do use it, this little file makes a big difference as it reduces the installation process to just a single command.