### PR TITLE
Add setting to support a different SSH key associate with one identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Printing the raw identity (for use in scripts)
 
 Priniting the local settings
 
-    $ git identity --current-settings
+    $ git identity --get-settings
     core.sshcommand ssh -i ~/.ssh/id_rsa_user
     user.email user@example.com
     user.identity user
@@ -112,7 +112,7 @@ This sets  `core.sshCommand="ssh -i ~/ssh/ssh-file"` in the local git config whe
 
 ### Creating a new identity 
 
-    ssh-keygen -t rsa -b 4096 -C "yourname@yourdomain" -f ~/.ssh/id_rsa_anotheraccount
+        ssh-keygen -t rsa -b 4096 -C "yourname@yourdomain" -f ~/.ssh/id_rsa_anotheraccount
     ssh-add id_rsa_anotheraccount
 
 ### Debugging a ssh connection problem 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Priniting the local settings
     user.identity user
     user.name First Last
 
+Retriving GIT_SSH_COMMAND or running command with that in the environment:
+
+    $ git identity -c my_other_identity
+    GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_myotheridentity"
+
+    $ git identity -c my_other_identity git clone git@github.com:me/myrepo.git
+    Cloning into 'myrepo'...
+
 Setting up GPG
 --------------
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ yourself.
 This is not an important part of your work, and setting this up should be really
 fast. That's where `git-identity` comes in: setting up your identity information only takes one command with it.
 
+*Note:* Identities are stored in the global git config. Using an identity copies the setting in the local repo git configuration. If you are changing the global config for one identity does *NOT* propagate the changes to the local repos. You will have use `git identity --update` in the repo folder to update the identity.
+
 Installing
 ----------
 
@@ -32,12 +34,17 @@ Usage
 
 Add an identity:
 
-    $ git identity --define <identity name> <user name> <user email>
+    $ git identity --define <identity name> <user name> <user email> [<ssh-file>] [<gpgkeyid>]
 
 Add a GPG key to the identity (see GPG specific information below)
 
 	$ git identity --define-gpg <identity name> <gpgkeyid>
 	Added GPG key DA221397A6FF5EZZ to [default] user <user@example.org> (GPG key: DA221397A6FF5EZZ)
+
+Add a SSH key to the identity
+
+	$ git identity --define-ssh <identity name> <ssh-file>
+	Added SSH key id_rsa_anotheraccount to [default] user <user@example.org> (SSH key: id_rsa_anotheraccount)
 
 Print the current identity:
 
@@ -48,6 +55,18 @@ Change identity:
 
     $ git identity user2
     Using identity: [default2] user2 <user2@example.org>
+
+Update identity:
+
+    $ git identity --update
+    Using identity: [user] First Last <user_new_email@example.com> (SSH key: id_rsa_user_new_key)
+    These are the changes:
+    1,2c1,2
+    <   core.sshcommand ssh  -i ~/.ssh/id_rsa_user
+    <   user.email user@example.com
+    ---
+    >   core.sshcommand ssh  -i ~/.ssh/id_rsa_user_new_key
+    >   user.email user_new_email@example.com
 
 List all identities:
 
@@ -71,7 +90,34 @@ Printing the raw identity (for use in scripts)
     $ git identity --print
     $ git identity --print <identity name>
 
+Priniting the local settings
+
+    $ git identity --current-settings
+    core.sshcommand ssh -i ~/.ssh/id_rsa_user
+    user.email user@example.com
+    user.identity user
+    user.name First Last
+
 Setting up GPG
 --------------
 
 More information about how to use GPG with `git-identity` may be found in [GPG_SETUP.md](GPG_SETUP.md)
+
+Setting up SSH
+--------------
+
+If you have a valid SSH key associate to the agent you do not have to do anything beside `git identity --define-ssh <identity name> <ssh-file>`.
+
+This sets  `core.sshCommand="ssh -i ~/ssh/ssh-file"` in the local git config when using that identity
+
+### Creating a new identity 
+
+    ssh-keygen -t rsa -b 4096 -C "yourname@yourdomain" -f ~/.ssh/id_rsa_anotheraccount
+    ssh-add id_rsa_anotheraccount
+
+### Debugging a ssh connection problem 
+
+    git identity --define-ssh <identity name> <ssh-file> <verbosity>
+
+With `verbosity=1` it will use `ssh -v`.
+With `verbosity=2` it will use `ssh -vvv`.

--- a/git-identity
+++ b/git-identity
@@ -1,15 +1,31 @@
 #!/bin/bash
 
-USAGE="[-d|--define] <identity> <name> <email> [<ssh-file>] [<gpgkeyid>]"
-USAGE="$USAGE | [-p|--print] <identity>"
-USAGE="$USAGE | [-s|--get-settings]"
-USAGE="$USAGE | [-r|--remove] <identity>"
-USAGE="$USAGE | [-l|--list]"
-USAGE="$USAGE | [-R|--list-raw]"
-USAGE="$USAGE | [--define-gpg] <gpgkeyid>"
-USAGE="$USAGE | [--define-ssh] <ssh-file> <ssh-verbosity>"
-USAGE="$USAGE | [-u|--update]"
-USAGE="$USAGE | <identity>"
+USAGE=`cat <<'EOF'
+[-d | --define] <identity> <name> <email> [<ssh-file>] [<gpgkeyid>]
+   or: git identity [-p | --print] [<identity>]
+   or: git identity [-s | --get-settings]
+   or: git identity [-r | --remove] <identity>
+   or: git identity [-l | --list]
+   or: git identity [-R | --list-raw]
+   or: git identity [--define-gpg] <gpgkeyid>
+   or: git identity [--define-ssh] <ssh-file> [<ssh-verbosity>]
+   or: git identity [-u | --update]
+   or: git identity <identity>
+
+Specific git-identity actions:
+   -d, --define          define new identity and optionally specify ssh-file and gpg key
+   -p, --print           print an indenttity or the current one
+   -s, --get-settings    get the current settings that git-identity can changes
+   -r, --remove          remove an identity
+   -l, --list            list all the identities
+   -R, --list-raw        list all identities without details
+   --define-gpg          Add gpg signature to the identity
+   --define-ssh          Add ssh key to an identity. If it does not have a path, assume '~/.ssh'
+                         Verbosity (0,1,2) of the ssh agent can also be specified
+   -u, --update          Refresh the local settings with the global settings of the current identity
+ 
+EOF
+`
 
 lookup () {
   local identity="$1"
@@ -141,7 +157,7 @@ print_raw_identity () {
     local name="$(lookup "$identity" name)"
     if [ "$name" != "" -a "$name" != " " ]
     then
-  echo "$(format_raw_identity "$identity")"
+      echo "$(format_raw_identity "$identity")"
     else
       echo "Identity $identity does not exist."
     fi

--- a/git-identity
+++ b/git-identity
@@ -11,8 +11,6 @@ USAGE="$USAGE | [--define-ssh] <ssh-file> <ssh-verbosity>"
 USAGE="$USAGE | [-u|--update]"
 USAGE="$USAGE | <identity>"
 
-. $(git --exec-path)/git-sh-setup
-
 lookup () {
   local identity="$1"
   local key="$2"
@@ -232,6 +230,16 @@ check_arguments () {
     exit 1
   fi
 }
+
+# For the some commands, it is ok not being in a git folder
+case $IDENTITY in
+  -l|--list|-R|--list-raw|-d|--define|--define-gpg|--define-ssh|-r|--remove|-p|--print)
+    # To prevent git-sh-setup to error out with  'fatal: not a git repository (or any of the parent directories): .git'
+    NONGIT_OK=1
+
+esac
+SUBDIRECTORY_OK=1
+. $(git --exec-path)/git-sh-setup
 
 case $IDENTITY in
   "") print_current_identity ;;

--- a/git-identity
+++ b/git-identity
@@ -134,7 +134,18 @@ print_raw_identity () {
     identity="$(git config user.identity)"
   fi
 
+  if [ "$identity" == "" -o "$identity" == " " ]
+  then
+    echo "You need to specify an identity or being in a repository with an identity set"
+  else 
+    local name="$(lookup "$identity" name)"
+    if [ "$name" != "" -a "$name" != " " ]
+    then
   echo "$(format_raw_identity "$identity")"
+    else
+      echo "Identity $identity does not exist."
+    fi
+  fi
 }
 
 print_current_identity () {

--- a/git-identity
+++ b/git-identity
@@ -2,7 +2,7 @@
 
 USAGE="[-d|--define] <identity> <name> <email> [<ssh-file>] [<gpgkeyid>]"
 USAGE="$USAGE | [-p|--print] <identity>"
-USAGE="$USAGE | [-c|--current-settings]"
+USAGE="$USAGE | [-s|--get-settings]"
 USAGE="$USAGE | [-r|--remove] <identity>"
 USAGE="$USAGE | [-l|--list]"
 USAGE="$USAGE | [-R|--list-raw]"
@@ -236,7 +236,7 @@ check_arguments () {
 case $IDENTITY in
   "") print_current_identity ;;
 
-  -c|--current-settings) get_current_settings ;;
+  -s|--get-settings) get_current_settings ;;
 
   -l|--list) list_identities ;;
 

--- a/git-identity
+++ b/git-identity
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-USAGE="[-d|--define] <identity> <name> <email>"
+USAGE="[-d|--define] <identity> <name> <email> [<ssh-file>] [<gpgkeyid>]"
 USAGE="$USAGE | [-p|--print] <identity>"
+USAGE="$USAGE | [-c|--current-settings]"
 USAGE="$USAGE | [-r|--remove] <identity>"
 USAGE="$USAGE | [-l|--list]"
 USAGE="$USAGE | [-R|--list-raw]"
 USAGE="$USAGE | [--define-gpg] <gpgkeyid>"
+USAGE="$USAGE | [--define-ssh] <ssh-file> <ssh-verbosity>"
+USAGE="$USAGE | [-u|--update]"
 USAGE="$USAGE | <identity>"
 
 . $(git --exec-path)/git-sh-setup
@@ -26,11 +29,24 @@ format_identity () {
 format_raw_identity () {
   local identity="$1"
   local gpgkey="$(lookup $identity signingkey)"
+  local sshkey="$(lookup $identity sshkey)"
+  local sshkeyverbosity="$(lookup $identity sshkeyverbosity)"
+
   
   local output="$(lookup "$identity" name) <$(lookup "$identity" email)>"
   if [ "$gpgkey" != "" -a "$gpgkey" != " " ];
   then
     output="$output (GPG key: $gpgkey)"
+  fi
+
+  if [ "$sshkey" != "" -a "$sshkey" != " " ];
+  then
+    local verbosity=""
+    if [ "$sshkeyverbosity" != "" -a "$sshkeyverbosity" != " " ];
+    then
+      verbosity=" with verbosity $sshkeyverbosity"
+    fi
+    output="$output (SSH key: $sshkey$verbosity)"
   fi
   
   echo "$output"
@@ -41,6 +57,8 @@ use_identity () {
   local name="$(lookup "$identity" name)"
   local email="$(lookup "$identity" email)"
   local gpgkey="$(lookup "$identity" signingkey)"
+  local sshkey="$(lookup $identity sshkey)"
+  local sshkeyverbosity="$(lookup $identity sshkeyverbosity)"
 
   if [ "$name" != "" -a "$name" != " " ]
   then
@@ -53,15 +71,49 @@ use_identity () {
     if [ "$gpgkey" != "" -a "$gpgkey" != " " ];
     then
       git config user.signingkey "$gpgkey"
-	  git config commit.gpgsign true
+	    git config commit.gpgsign true
     else
       git config --unset user.signingkey
       git config --unset commit.gpgsign
+    fi
+  
+    # Enable or disable SSH key usage
+    if [ "$sshkey" != "" -a "$sshkey" != " " ];
+    then
+      local verbosity=""
+      case $sshkeyverbosity in
+        1) verbosity="-v " ;;
+        2) verbosity="-vvv " ;;
+        *) verbosity="" ;;
+      esac
+
+      if [[ $sshkey != '/'* ]] && [[ $sshkey != '.'* ]]
+      then
+        sshkey="~/.ssh/$sshkey"
+      fi
+      git config core.sshCommand "ssh $verbosity-i $sshkey"
+    else
+      git config --unset core.sshCommand
     fi
   else
     echo "Identity $identity does not exist. Doing nothing..."
 	echo "$(print_current_identity)"
   fi
+}
+
+update_identity () {
+    local identity="$(git config user.identity)"
+    local prev_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
+    use_identity "$identity"
+    local curr_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
+    local diff_string="$(diff --color=always <(echo "$prev_settings") <(echo "$curr_settings"))"
+    if [ "$diff_string" != "" -a "$diff_string" != " " ];
+    then
+      echo "These local setting changed:"
+      echo "$diff_string"
+    else
+      echo "Settings are current. No changes were made."
+    fi
 }
 
 list_raw_identities () {
@@ -98,13 +150,30 @@ print_current_identity () {
   fi
 }
 
+get_current_settings () {
+    git config --local --get-regexp '^(user\.|commit\.gpgsign|core.ssh[cC]ommand)' | sort -u
+}
+
 define_identity () {
   local identity="$1"
   local name="$2"
   local email="$3"
+  local sshkey="$4"
+  local gpgkey="$5"
 
   git config --global identity."$identity".name "$name"
   git config --global identity."$identity".email "$email"
+
+  if [ "$sshkey" != "" -a "$sshkey" != " " ];
+  then
+    define_ssh $identity $sshkey
+  fi
+
+  if [ "$gpgkey" != "" -a "$gpgkey" != " " ];
+  then
+    define_gpg $identity $gpgkey
+  fi
+
   echo "Created $(format_identity "$identity")"
   echo "Enter 'git identity $identity' to use it in the current repository."
 }
@@ -133,6 +202,28 @@ define_gpg () {
   fi
 }
 
+define_ssh () {
+  local identity="$1"
+  local sshkey="$2"
+  local sshkeyverbosity="$3"
+  local name="$(lookup "$identity" name)"
+  
+  if [ "$name" != "" -a "$name" != " " ]
+  then
+    git config --global identity."$identity".sshkey "$sshkey"
+    echo "Added SSH key $sshkey to $(format_identity "$identity")"
+
+    if [ "$sshkeyverbosity" != "" -a "$sshkeyverbosity" != " " ]
+    then
+      git config --global identity."$identity".sshkeyverbosity "$sshkeyverbosity"
+    fi
+  
+    use_identity "$identity"
+  else
+    echo "Error: could not define SSH key for undefined identity '$identity'"
+  fi
+}
+
 IDENTITY="$1"
 
 check_arguments () {
@@ -145,6 +236,8 @@ check_arguments () {
 case $IDENTITY in
   "") print_current_identity ;;
 
+  -c|--current-settings) get_current_settings ;;
+
   -l|--list) list_identities ;;
 
   -R|--list-raw) list_raw_identities ;;
@@ -152,13 +245,19 @@ case $IDENTITY in
   -d|--define)
     shift
     check_arguments $# 3
-    define_identity "$1" "$2" "$3"
+    define_identity "$1" "$2" "$3" "$4" "$5"
     ;;
 
   --define-gpg)
     shift
-	check_arguments $# 2
-	define_gpg "$1" "$2"
+	  check_arguments $# 2
+	  define_gpg "$1" "$2"
+	;;
+
+  --define-ssh)
+    shift
+	  check_arguments $# 2
+	  define_ssh "$1" "$2" "$3"
 	;;
 	
   -r|--remove)
@@ -171,6 +270,8 @@ case $IDENTITY in
     shift
     print_raw_identity "$1"
     ;;
+
+  -u|--update) update_identity "$1" ;;
   
   *) use_identity "$IDENTITY" ;;
 esac

--- a/git-identity
+++ b/git-identity
@@ -10,19 +10,23 @@ USAGE=`cat <<'EOF'
    or: git identity [--define-gpg] <gpgkeyid>
    or: git identity [--define-ssh] <ssh-file> [<ssh-verbosity>]
    or: git identity [-u | --update]
+   or: git identity [-c | --get-shell-command] [<identity>] [<command>]
    or: git identity <identity>
 
 Specific git-identity actions:
-   -d, --define          define new identity and optionally specify ssh-file and gpg key
-   -p, --print           print an indenttity or the current one
-   -s, --get-settings    get the current settings that git-identity can changes
-   -r, --remove          remove an identity
-   -l, --list            list all the identities
-   -R, --list-raw        list all identities without details
-   --define-gpg          Add gpg signature to the identity
-   --define-ssh          Add ssh key to an identity. If it does not have a path, assume '~/.ssh'
-                         Verbosity (0,1,2) of the ssh agent can also be specified
-   -u, --update          Refresh the local settings with the global settings of the current identity
+   -d, --define            define new identity and optionally specify ssh-file and gpg key
+   -p, --print             print an indenttity or the current one
+   -s, --get-settings      get the current settings that git-identity can changes
+   -r, --remove            remove an identity
+   -l, --list              list all the identities
+   -R, --list-raw          list all identities without details
+   --define-gpg            add gpg signature to the identity
+   --define-ssh            add ssh key to an identity. If it does not have a path, assume '~/.ssh'
+                           verbosity (0,1,2) of the ssh agent can also be specified
+   -u, --update            refresh the local settings with the global settings of the current identity
+   -c,--get-shell-command  get GIT_SSH_COMMAND environment variable for for an identity
+                           if it followed by more parameter, execute a command with it
+
  
 EOF
 `
@@ -66,13 +70,64 @@ format_raw_identity () {
   echo "$output"
 }
 
+get_ssh_command () {
+  local identity="$1"
+  local sshkey="$(lookup $identity sshkey)"
+  local sshkeyverbosity="$(lookup $identity sshkeyverbosity)"
+
+  if [ "$sshkey" != "" -a "$sshkey" != " " ];
+  then
+    local verbosity=""
+    case $sshkeyverbosity in
+      1) verbosity="-v " ;;
+      2) verbosity="-vvv " ;;
+      *) verbosity="" ;;
+    esac
+
+    if [[ $sshkey != '/'* ]] && [[ $sshkey != '.'* ]]
+    then
+      sshkey="~/.ssh/$sshkey"
+    fi
+    echo "ssh $verbosity-i $sshkey"
+  else
+    echo ''
+  fi
+}
+
+env_ssh_command () {
+  local identity="$1"
+  shift
+
+  if [ "x$identity" = "x" ]; then
+    identity="$(git config user.identity)"
+  fi
+
+  if [ "$identity" == "" -o "$identity" == " " ]
+  then
+    echo "You need to specify an identity or being in a repository with an identity set"
+  else 
+    local name="$(lookup "$identity" name)"
+    if [ "$name" != "" -a "$name" != " " ]
+    then
+      local sshCommand="$(get_ssh_command $identity)"
+      if [ $# == 0 ]
+      then
+        echo "GIT_SSH_COMMAND=\"$sshCommand\""
+      else 
+        GIT_SSH_COMMAND="$sshCommand" "$@"
+      fi
+    else 
+      echo "Identity $identity does not exist. Doing nothing..."
+    fi
+  fi  
+}
+
 use_identity () {
   local identity="$1"
   local name="$(lookup "$identity" name)"
   local email="$(lookup "$identity" email)"
   local gpgkey="$(lookup "$identity" signingkey)"
-  local sshkey="$(lookup $identity sshkey)"
-  local sshkeyverbosity="$(lookup $identity sshkeyverbosity)"
+  local sshCommand="$(get_ssh_command $identity)"
 
   if [ "$name" != "" -a "$name" != " " ]
   then
@@ -92,21 +147,10 @@ use_identity () {
     fi
   
     # Enable or disable SSH key usage
-    if [ "$sshkey" != "" -a "$sshkey" != " " ];
+    if [ sshCommand != "" ];
     then
-      local verbosity=""
-      case $sshkeyverbosity in
-        1) verbosity="-v " ;;
-        2) verbosity="-vvv " ;;
-        *) verbosity="" ;;
-      esac
-
-      if [[ $sshkey != '/'* ]] && [[ $sshkey != '.'* ]]
-      then
-        sshkey="~/.ssh/$sshkey"
-      fi
-      git config core.sshCommand "ssh $verbosity-i $sshkey"
-    else
+      git config core.sshCommand "$sshCommand"
+    else 
       git config --unset core.sshCommand
     fi
   else
@@ -224,7 +268,7 @@ define_gpg () {
     local current_identity="$(git config user.identity)"
     if [ "$current_identity" == "$identity"]
     then 
-    use_identity "$identity"
+      use_identity "$identity"
     fi
   else
     echo "Error: could not define GPG key for undefined identity '$identity'"
@@ -250,7 +294,7 @@ define_ssh () {
     local current_identity="$(git config user.identity)"
     if [ "$current_identity" == "$identity"]
     then 
-    use_identity "$identity"
+      use_identity "$identity"
     fi
   else
     echo "Error: could not define SSH key for undefined identity '$identity'"
@@ -268,7 +312,7 @@ check_arguments () {
 
 # For the some commands, it is ok not being in a git folder
 case $IDENTITY in
-  -l|--list|-R|--list-raw|-d|--define|--define-gpg|--define-ssh|-r|--remove|-p|--print)
+  -l|--list|-R|--list-raw|-d|--define|--define-gpg|--define-ssh|-r|--remove|-p|--print|-c|--set-shell-command)
     # To prevent git-sh-setup to error out with  'fatal: not a git repository (or any of the parent directories): .git'
     NONGIT_OK=1
 
@@ -315,6 +359,11 @@ case $IDENTITY in
     ;;
 
   -u|--update) update_identity "$1" ;;
+
+  -c|--get-shell-command)
+    shift
+    env_ssh_command "$@"
+    ;;
   
   *) use_identity "$IDENTITY" ;;
 esac

--- a/git-identity
+++ b/git-identity
@@ -221,7 +221,11 @@ define_gpg () {
     git config --global identity."$identity".signingkey "$gpgkey"
     echo "Added GPG key $gpgkey to $(format_identity "$identity")"
   
+    local current_identity="$(git config user.identity)"
+    if [ "$current_identity" == "$identity"]
+    then 
     use_identity "$identity"
+    fi
   else
     echo "Error: could not define GPG key for undefined identity '$identity'"
   fi
@@ -243,7 +247,11 @@ define_ssh () {
       git config --global identity."$identity".sshkeyverbosity "$sshkeyverbosity"
     fi
   
+    local current_identity="$(git config user.identity)"
+    if [ "$current_identity" == "$identity"]
+    then 
     use_identity "$identity"
+    fi
   else
     echo "Error: could not define SSH key for undefined identity '$identity'"
   fi

--- a/git-identity.bash-completion
+++ b/git-identity.bash-completion
@@ -7,7 +7,7 @@ _git_identity () {
 	# git identity -h | tr '|' '\n'|grep -oE '\-.+'|cut -f1 -d']' |tr '\n' ' '
 	# The grep regex is a bit hack-y, but this is just over-optimizing anyway
 	# Whenever you add more commands just come add them here
-	local commands="-d --define --define-gpg -r --remove -l --list -R --list-raw -p --print -s --get-settings --define-ssh -u --update"
+	local commands="-d --define --define-gpg -r --remove -l --list -R --list-raw -p --print -s --get-settings --define-ssh -u --update -h"
 
 	case "$cur" in
 		-*)

--- a/git-identity.bash-completion
+++ b/git-identity.bash-completion
@@ -7,7 +7,7 @@ _git_identity () {
 	# git identity -h | tr '|' '\n'|grep -oE '\-.+'|cut -f1 -d']' |tr '\n' ' '
 	# The grep regex is a bit hack-y, but this is just over-optimizing anyway
 	# Whenever you add more commands just come add them here
-	local commands="-d --define --define-gpg -r --remove -l --list -R --list-raw -p --print"
+	local commands="-d --define --define-gpg -r --remove -l --list -R --list-raw -p --print -c --current-settings --define-ssh -u --update"
 
 	case "$cur" in
 		-*)

--- a/git-identity.bash-completion
+++ b/git-identity.bash-completion
@@ -7,7 +7,7 @@ _git_identity () {
 	# git identity -h | tr '|' '\n'|grep -oE '\-.+'|cut -f1 -d']' |tr '\n' ' '
 	# The grep regex is a bit hack-y, but this is just over-optimizing anyway
 	# Whenever you add more commands just come add them here
-	local commands="-d --define --define-gpg -r --remove -l --list -R --list-raw -p --print -c --current-settings --define-ssh -u --update"
+	local commands="-d --define --define-gpg -r --remove -l --list -R --list-raw -p --print -s --get-settings --define-ssh -u --update"
 
 	case "$cur" in
 		-*)

--- a/git-identity.bash-completion
+++ b/git-identity.bash-completion
@@ -7,7 +7,7 @@ _git_identity () {
 	# git identity -h | tr '|' '\n'|grep -oE '\-.+'|cut -f1 -d']' |tr '\n' ' '
 	# The grep regex is a bit hack-y, but this is just over-optimizing anyway
 	# Whenever you add more commands just come add them here
-	local commands="-d --define --define-gpg -r --remove -l --list -R --list-raw -p --print -s --get-settings --define-ssh -u --update -h"
+	local commands="-d --define --define-gpg -r --remove -l --list -R --list-raw -p --print -s --get-settings --define-ssh -u --update -h  -c --get-shell-command"
 
 	case "$cur" in
 		-*)

--- a/git-identity.zsh-completion
+++ b/git-identity.zsh-completion
@@ -11,6 +11,7 @@ options=(
 {-p,--print}':Print an identity'
 {-s,--get-settings}':Print current local settings'
 {-u,--update}':Update local settings based on the current identity'
+{-c,--get-shell-command}':Get GIT_SSH_COMMAND for an identiy or current identity'
 {--define-ssh}':Add a ssh key for the identity'
 )
 

--- a/git-identity.zsh-completion
+++ b/git-identity.zsh-completion
@@ -9,6 +9,9 @@ options=(
 {--define-gpg}':Assign a GPG key with an identity'
 {-r,--remove}':Remove an identity'
 {-p,--print}':Print an identity'
+{-c,--current-settings}':Print current local settings'
+{-u,--update}':Update local settings based on the current identity'
+{--define-ssh}':Add a ssh key for the identity'
 )
 
 if (( CURRENT < 3 )); then

--- a/git-identity.zsh-completion
+++ b/git-identity.zsh-completion
@@ -9,7 +9,7 @@ options=(
 {--define-gpg}':Assign a GPG key with an identity'
 {-r,--remove}':Remove an identity'
 {-p,--print}':Print an identity'
-{-c,--current-settings}':Print current local settings'
+{-s,--get-settings}':Print current local settings'
 {-u,--update}':Update local settings based on the current identity'
 {--define-ssh}':Add a ssh key for the identity'
 )


### PR DESCRIPTION
It also adds:

Support for defining an identity that support SSH key and GPG key with one line
Support for printing local settings associated to the identity
Support for updating local repo setting from the current identity