### PR TITLE
fix error at line 295

### DIFF
--- a/git-identity
+++ b/git-identity
@@ -292,7 +292,7 @@ define_ssh () {
     fi
   
     local current_identity="$(git config user.identity)"
-    if [ "$current_identity" == "$identity"]
+    if [ "$current_identity" == "$identity" ]
     then 
       use_identity "$identity"
     fi


### PR DESCRIPTION
When added an identity, the line 295 showed an error allegedly by a missing "]". The error was caused by an incorrect spacing between the text and the ] at the if statement