### PR TITLE
Appease shellcheck

### DIFF
--- a/git-identity
+++ b/git-identity
@@ -142,7 +142,7 @@ use_identity () {
     if [ -n "$gpgkey" ];
     then
       git config user.signingkey "$gpgkey"
-	    git config commit.gpgsign true
+      git config commit.gpgsign true
     else
       git config --unset user.signingkey
       git config --unset commit.gpgsign
@@ -162,18 +162,18 @@ use_identity () {
 }
 
 update_identity () {
-    local identity="$(git config user.identity)"
-    local prev_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
-    use_identity "$identity"
-    local curr_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
-    local diff_string="$(diff --color=always <(echo "$prev_settings") <(echo "$curr_settings"))"
-    if [ -n "$diff_string" ];
-    then
-      echo "These local setting changed:"
-      echo "$diff_string"
-    else
-      echo "Settings are current. No changes were made."
-    fi
+  local identity="$(git config user.identity)"
+  local prev_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
+  use_identity "$identity"
+  local curr_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
+  local diff_string="$(diff --color=always <(echo "$prev_settings") <(echo "$curr_settings"))"
+  if [ -n "$diff_string" ];
+  then
+    echo "These local setting changed:"
+    echo "$diff_string"
+  else
+    echo "Settings are current. No changes were made."
+  fi
 }
 
 list_raw_identities () {
@@ -222,7 +222,7 @@ print_current_identity () {
 }
 
 get_current_settings () {
-    git config --local --get-regexp '^(user\.|commit\.gpgsign|core.ssh[cC]ommand)' | sort -u
+  git config --local --get-regexp '^(user\.|commit\.gpgsign|core.ssh[cC]ommand)' | sort -u
 }
 
 define_identity () {
@@ -339,15 +339,15 @@ case $IDENTITY in
 
   --define-gpg)
     shift
-	  check_arguments $# 2
-	  define_gpg "$1" "$2"
-	;;
+    check_arguments $# 2
+    define_gpg "$1" "$2"
+    ;;
 
   --define-ssh)
     shift
-	  check_arguments $# 2
-	  define_ssh "$1" "$2" "$3"
-	;;
+    check_arguments $# 2
+    define_ssh "$1" "$2" "$3"
+    ;;
 
   -r|--remove)
     shift

--- a/git-identity
+++ b/git-identity
@@ -5,27 +5,27 @@
 # shellcheck disable=SC2034
 USAGE="$(cat <<'EOF'
 [-d | --define] <identity> <name> <email> [<ssh-file>] [<gpgkeyid>]
+   or: git identity [--define-gpg] <gpgkeyid>
+   or: git identity [--define-ssh] <ssh-file> [<ssh-verbosity>]
    or: git identity [-p | --print] [<identity>]
    or: git identity [-s | --get-settings]
    or: git identity [-r | --remove] <identity>
    or: git identity [-l | --list]
    or: git identity [-R | --list-raw]
-   or: git identity [--define-gpg] <gpgkeyid>
-   or: git identity [--define-ssh] <ssh-file> [<ssh-verbosity>]
    or: git identity [-u | --update]
    or: git identity [-c | --get-shell-command] [<identity>] [<command>]
    or: git identity <identity>
 
 Specific git-identity actions:
    -d, --define            define new identity and optionally specify ssh-file and gpg key
-   -p, --print             print an indenttity or the current one
-   -s, --get-settings      get the current settings that git-identity can changes
-   -r, --remove            remove an identity
-   -l, --list              list all the identities
-   -R, --list-raw          list all identities without details
    --define-gpg            add gpg signature to the identity
    --define-ssh            add ssh key to an identity. If it does not have a path, assume '~/.ssh'
                            verbosity (0,1,2) of the ssh agent can also be specified
+   -p, --print             print an indenttity or the current one
+   -r, --remove            remove an identity
+   -s, --get-settings      get the current settings that git-identity can changes
+   -l, --list              list all the identities
+   -R, --list-raw          list all identities without details
    -u, --update            refresh the local settings with the global settings of the current identity
    -c,--get-shell-command  get GIT_SSH_COMMAND environment variable for for an identity
                            if it followed by more parameter, execute a command with it
@@ -325,12 +325,6 @@ SUBDIRECTORY_OK=1
 case $IDENTITY in
   "") print_current_identity ;;
 
-  -s|--get-settings) get_current_settings ;;
-
-  -l|--list) list_identities ;;
-
-  -R|--list-raw) list_raw_identities ;;
-
   -d|--define)
     shift
     check_arguments $# 3
@@ -349,16 +343,22 @@ case $IDENTITY in
     define_ssh "$1" "$2" "$3"
     ;;
 
+  -p|--print)
+    shift
+    print_raw_identity "$1"
+    ;;
+
+  -s|--get-settings) get_current_settings ;;
+
   -r|--remove)
     shift
     check_arguments $# 1
     remove_identity "$1"
     ;;
 
-  -p|--print)
-    shift
-    print_raw_identity "$1"
-    ;;
+  -l|--list) list_identities ;;
+
+  -R|--list-raw) list_raw_identities ;;
 
   -u|--update) update_identity "$1" ;;
 

--- a/git-identity
+++ b/git-identity
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-USAGE=`cat <<'EOF'
+# TODO: Support non-stardard identity store
+
+# shellcheck disable=SC2034
+USAGE="$(cat <<'EOF'
 [-d | --define] <identity> <name> <email> [<ssh-file>] [<gpgkeyid>]
    or: git identity [-p | --print] [<identity>]
    or: git identity [-s | --get-settings]
@@ -26,16 +29,14 @@ Specific git-identity actions:
    -u, --update            refresh the local settings with the global settings of the current identity
    -c,--get-shell-command  get GIT_SSH_COMMAND environment variable for for an identity
                            if it followed by more parameter, execute a command with it
-
- 
 EOF
-`
+)"
 
 lookup () {
   local identity="$1"
   local key="$2"
 
-  git config "identity.$identity.$key"
+  git config --get "identity.$identity.$key"
 }
 
 format_identity () {
@@ -46,36 +47,37 @@ format_identity () {
 
 format_raw_identity () {
   local identity="$1"
-  local gpgkey="$(lookup $identity signingkey)"
-  local sshkey="$(lookup $identity sshkey)"
-  local sshkeyverbosity="$(lookup $identity sshkeyverbosity)"
+  local gpgkey="$(lookup "$identity" signingkey)"
+  local sshkey="$(lookup "$identity" sshkey)"
+  local sshkeyverbosity="$(lookup "$identity" sshkeyverbosity)"
 
-  
+
   local output="$(lookup "$identity" name) <$(lookup "$identity" email)>"
-  if [ "$gpgkey" != "" -a "$gpgkey" != " " ];
+  if [ -n "$gpgkey" ]
   then
     output="$output (GPG key: $gpgkey)"
   fi
 
-  if [ "$sshkey" != "" -a "$sshkey" != " " ];
+  if [ -n "$sshkey" ];
   then
     local verbosity=""
-    if [ "$sshkeyverbosity" != "" -a "$sshkeyverbosity" != " " ];
+    if [ -n "$sshkeyverbosity" ];
     then
       verbosity=" with verbosity $sshkeyverbosity"
     fi
     output="$output (SSH key: $sshkey$verbosity)"
   fi
-  
+
   echo "$output"
 }
 
+# TODO: This should return an array ()?
 get_ssh_command () {
   local identity="$1"
-  local sshkey="$(lookup $identity sshkey)"
-  local sshkeyverbosity="$(lookup $identity sshkeyverbosity)"
+  local sshkey="$(lookup "$identity" sshkey)"
+  local sshkeyverbosity="$(lookup "$identity" sshkeyverbosity)"
 
-  if [ "$sshkey" != "" -a "$sshkey" != " " ];
+  if [ -n "$sshkey" ];
   then
     local verbosity=""
     case $sshkeyverbosity in
@@ -86,7 +88,7 @@ get_ssh_command () {
 
     if [[ $sshkey != '/'* ]] && [[ $sshkey != '.'* ]]
     then
-      sshkey="~/.ssh/$sshkey"
+      sshkey="$HOME/.ssh/$sshkey"
     fi
     echo "ssh $verbosity-i $sshkey"
   else
@@ -102,24 +104,24 @@ env_ssh_command () {
     identity="$(git config user.identity)"
   fi
 
-  if [ "$identity" == "" -o "$identity" == " " ]
+  if [ -z "$identity" ];
   then
     echo "You need to specify an identity or being in a repository with an identity set"
-  else 
+  else
     local name="$(lookup "$identity" name)"
-    if [ "$name" != "" -a "$name" != " " ]
+    if [ -n "$name" ];
     then
-      local sshCommand="$(get_ssh_command $identity)"
+      local sshCommand="$(get_ssh_command "$identity")"
       if [ $# == 0 ]
       then
         echo "GIT_SSH_COMMAND=\"$sshCommand\""
-      else 
+      else
         GIT_SSH_COMMAND="$sshCommand" "$@"
       fi
-    else 
+    else
       echo "Identity $identity does not exist. Doing nothing..."
     fi
-  fi  
+  fi
 }
 
 use_identity () {
@@ -127,17 +129,17 @@ use_identity () {
   local name="$(lookup "$identity" name)"
   local email="$(lookup "$identity" email)"
   local gpgkey="$(lookup "$identity" signingkey)"
-  local sshCommand="$(get_ssh_command $identity)"
+  local sshCommand="$(get_ssh_command "$identity")"
 
-  if [ "$name" != "" -a "$name" != " " ]
+  if [ -n "$name" ];
   then
     echo "Using identity: $(format_identity "$identity")"
     git config user.identity "$identity"
     git config user.name "$name"
     git config user.email "$email"
-  
+
     # Enable or disable GPG key usage
-    if [ "$gpgkey" != "" -a "$gpgkey" != " " ];
+    if [ -n "$gpgkey" ];
     then
       git config user.signingkey "$gpgkey"
 	    git config commit.gpgsign true
@@ -145,17 +147,17 @@ use_identity () {
       git config --unset user.signingkey
       git config --unset commit.gpgsign
     fi
-  
+
     # Enable or disable SSH key usage
-    if [ "$sshCommand" != "" ];
+    if [ -n "$sshCommand" ];
     then
       git config core.sshCommand "$sshCommand"
-    else 
+    else
       git config --unset core.sshCommand
     fi
   else
     echo "Identity $identity does not exist. Doing nothing..."
-	echo "$(print_current_identity)"
+    print_current_identity
   fi
 }
 
@@ -165,7 +167,7 @@ update_identity () {
     use_identity "$identity"
     local curr_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
     local diff_string="$(diff --color=always <(echo "$prev_settings") <(echo "$curr_settings"))"
-    if [ "$diff_string" != "" -a "$diff_string" != " " ];
+    if [ -n "$diff_string" ];
     then
       echo "These local setting changed:"
       echo "$diff_string"
@@ -194,14 +196,14 @@ print_raw_identity () {
     identity="$(git config user.identity)"
   fi
 
-  if [ "$identity" == "" -o "$identity" == " " ]
+  if [ -z "$identity" ];
   then
     echo "You need to specify an identity or being in a repository with an identity set"
-  else 
+  else
     local name="$(lookup "$identity" name)"
-    if [ "$name" != "" -a "$name" != " " ]
+    if [ -n "$name" ];
     then
-      echo "$(format_raw_identity "$identity")"
+      format_raw_identity "$identity"
     else
       echo "Identity $identity does not exist."
     fi
@@ -211,7 +213,7 @@ print_raw_identity () {
 print_current_identity () {
   local identity="$(git config user.identity)"
 
-  if [ "$identity" != "" -a "$identity" != " " ]
+  if [ -n "$identity" ];
   then
     echo "Current identity: $(format_identity "$identity")"
   else
@@ -233,14 +235,14 @@ define_identity () {
   git config --global identity."$identity".name "$name"
   git config --global identity."$identity".email "$email"
 
-  if [ "$sshkey" != "" -a "$sshkey" != " " ];
+  if [ -n "$sshkey" ];
   then
-    define_ssh $identity $sshkey
+    define_ssh "$identity" "$sshkey"
   fi
 
-  if [ "$gpgkey" != "" -a "$gpgkey" != " " ];
+  if [ -n "$gpgkey" ];
   then
-    define_gpg $identity $gpgkey
+    define_gpg "$identity" "$gpgkey"
   fi
 
   echo "Created $(format_identity "$identity")"
@@ -259,15 +261,15 @@ define_gpg () {
   local identity="$1"
   local gpgkey="$2"
   local name="$(lookup "$identity" name)"
-  
-  if [ "$name" != "" -a "$name" != " " ]
+
+  if [ -n "$name" ];
   then
     git config --global identity."$identity".signingkey "$gpgkey"
     echo "Added GPG key $gpgkey to $(format_identity "$identity")"
-  
+
     local current_identity="$(git config user.identity)"
-    if [ "$current_identity" == "$identity"]
-    then 
+    if [ "$current_identity" == "$identity" ]
+    then
       use_identity "$identity"
     fi
   else
@@ -280,20 +282,20 @@ define_ssh () {
   local sshkey="$2"
   local sshkeyverbosity="$3"
   local name="$(lookup "$identity" name)"
-  
-  if [ "$name" != "" -a "$name" != " " ]
+
+  if [ -n "$name" ];
   then
     git config --global identity."$identity".sshkey "$sshkey"
     echo "Added SSH key $sshkey to $(format_identity "$identity")"
 
-    if [ "$sshkeyverbosity" != "" -a "$sshkeyverbosity" != " " ]
+    if [ -n "$sshkeyverbosity" ];
     then
       git config --global identity."$identity".sshkeyverbosity "$sshkeyverbosity"
     fi
-  
+
     local current_identity="$(git config user.identity)"
     if [ "$current_identity" == "$identity" ]
-    then 
+    then
       use_identity "$identity"
     fi
   else
@@ -304,7 +306,7 @@ define_ssh () {
 IDENTITY="$1"
 
 check_arguments () {
-  if [ $1 -lt $2 ]; then
+  if [ "$1" -lt "$2" ]; then
     usage
     exit 1
   fi
@@ -315,10 +317,10 @@ case $IDENTITY in
   -l|--list|-R|--list-raw|-d|--define|--define-gpg|--define-ssh|-r|--remove|-p|--print|-c|--set-shell-command)
     # To prevent git-sh-setup to error out with  'fatal: not a git repository (or any of the parent directories): .git'
     NONGIT_OK=1
-
 esac
 SUBDIRECTORY_OK=1
-. $(git --exec-path)/git-sh-setup
+# shellcheck source=/usr/lib/git-core/git-sh-setup
+. "$(git --exec-path)/git-sh-setup"
 
 case $IDENTITY in
   "") print_current_identity ;;
@@ -346,7 +348,7 @@ case $IDENTITY in
 	  check_arguments $# 2
 	  define_ssh "$1" "$2" "$3"
 	;;
-	
+
   -r|--remove)
     shift
     check_arguments $# 1
@@ -364,6 +366,6 @@ case $IDENTITY in
     shift
     env_ssh_command "$@"
     ;;
-  
+
   *) use_identity "$IDENTITY" ;;
 esac

--- a/git-identity
+++ b/git-identity
@@ -225,6 +225,7 @@ get_current_settings () {
   git config --local --get-regexp '^(user\.|commit\.gpgsign|core.ssh[cC]ommand)' | sort -u
 }
 
+# TODO: Make this interactive, at least for the code name/email
 define_identity () {
   local identity="$1"
   local name="$2"

--- a/git-identity
+++ b/git-identity
@@ -147,7 +147,7 @@ use_identity () {
     fi
   
     # Enable or disable SSH key usage
-    if [ sshCommand != "" ];
+    if [ "$sshCommand" != "" ];
     then
       git config core.sshCommand "$sshCommand"
     else 

--- a/git-identity
+++ b/git-identity
@@ -46,13 +46,14 @@ format_identity () {
 }
 
 format_raw_identity () {
-  local identity="$1"
-  local gpgkey="$(lookup "$identity" signingkey)"
-  local sshkey="$(lookup "$identity" sshkey)"
-  local sshkeyverbosity="$(lookup "$identity" sshkeyverbosity)"
+  local identity gpgkey sshkey sshkeyverbosity output
+  identity="$1"
+  gpgkey="$(lookup "$identity" signingkey)"
+  sshkey="$(lookup "$identity" sshkey)"
+  sshkeyverbosity="$(lookup "$identity" sshkeyverbosity)"
 
 
-  local output="$(lookup "$identity" name) <$(lookup "$identity" email)>"
+  output="$(lookup "$identity" name) <$(lookup "$identity" email)>"
   if [ -n "$gpgkey" ]
   then
     output="$output (GPG key: $gpgkey)"
@@ -73,9 +74,10 @@ format_raw_identity () {
 
 # TODO: This should return an array ()?
 get_ssh_command () {
-  local identity="$1"
-  local sshkey="$(lookup "$identity" sshkey)"
-  local sshkeyverbosity="$(lookup "$identity" sshkeyverbosity)"
+  local identit sshkey sshkeyverbosity
+  identity="$1"
+  sshkey="$(lookup "$identity" sshkey)"
+  sshkeyverbosity="$(lookup "$identity" sshkeyverbosity)"
 
   if [ -n "$sshkey" ];
   then
@@ -97,7 +99,8 @@ get_ssh_command () {
 }
 
 env_ssh_command () {
-  local identity="$1"
+  local identity name sshCommand
+  identity="$1"
   shift
 
   if [ "x$identity" = "x" ]; then
@@ -108,10 +111,10 @@ env_ssh_command () {
   then
     echo "You need to specify an identity or being in a repository with an identity set"
   else
-    local name="$(lookup "$identity" name)"
+    name="$(lookup "$identity" name)"
     if [ -n "$name" ];
     then
-      local sshCommand="$(get_ssh_command "$identity")"
+      sshCommand="$(get_ssh_command "$identity")"
       if [ $# == 0 ]
       then
         echo "GIT_SSH_COMMAND=\"$sshCommand\""
@@ -125,11 +128,12 @@ env_ssh_command () {
 }
 
 use_identity () {
-  local identity="$1"
-  local name="$(lookup "$identity" name)"
-  local email="$(lookup "$identity" email)"
-  local gpgkey="$(lookup "$identity" signingkey)"
-  local sshCommand="$(get_ssh_command "$identity")"
+  local identity name email gpgkey sshCommand
+  identity="$1"
+  name="$(lookup "$identity" name)"
+  email="$(lookup "$identity" email)"
+  gpgkey="$(lookup "$identity" signingkey)"
+  sshCommand="$(get_ssh_command "$identity")"
 
   if [ -n "$name" ];
   then
@@ -162,11 +166,12 @@ use_identity () {
 }
 
 update_identity () {
-  local identity="$(git config user.identity)"
-  local prev_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
+  local identity prev_settings curr_settings diff_string
+  identity="$(git config user.identity)"
+  prev_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
   use_identity "$identity"
-  local curr_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
-  local diff_string="$(diff --color=always <(echo "$prev_settings") <(echo "$curr_settings"))"
+  curr_settings=$(get_current_settings "$identity" | sed -e 's/^/  /')
+  diff_string="$(diff --color=always <(echo "$prev_settings") <(echo "$curr_settings"))"
   if [ -n "$diff_string" ];
   then
     echo "These local setting changed:"
@@ -181,7 +186,8 @@ list_raw_identities () {
 }
 
 list_identities () {
-  local identities="$(list_raw_identities)"
+  local identities
+  identities="$(list_raw_identities)"
 
   echo "Available identities:"
   for identity in $identities; do
@@ -190,7 +196,8 @@ list_identities () {
 }
 
 print_raw_identity () {
-  local identity="$1"
+  local identity name
+  identity="$1"
 
   if [ "x$identity" = "x" ]; then
     identity="$(git config user.identity)"
@@ -200,7 +207,7 @@ print_raw_identity () {
   then
     echo "You need to specify an identity or being in a repository with an identity set"
   else
-    local name="$(lookup "$identity" name)"
+    name="$(lookup "$identity" name)"
     if [ -n "$name" ];
     then
       format_raw_identity "$identity"
@@ -211,7 +218,8 @@ print_raw_identity () {
 }
 
 print_current_identity () {
-  local identity="$(git config user.identity)"
+  local identity
+  identity="$(git config user.identity)"
 
   if [ -n "$identity" ];
   then
@@ -251,24 +259,26 @@ define_identity () {
 }
 
 remove_identity () {
-  local identity="$1"
-  local formated_identity="$(format_identity "$identity")"
+  local identity formated_identity
+  identity="$1"
+  formated_identity="$(format_identity "$identity")"
 
   git config --global --remove-section identity."$identity"
   echo "Removed $formated_identity"
 }
 
 define_gpg () {
-  local identity="$1"
-  local gpgkey="$2"
-  local name="$(lookup "$identity" name)"
+  local indentity gpgkey name current_identity
+  identity="$1"
+  gpgkey="$2"
+  name="$(lookup "$identity" name)"
 
   if [ -n "$name" ];
   then
     git config --global identity."$identity".signingkey "$gpgkey"
     echo "Added GPG key $gpgkey to $(format_identity "$identity")"
 
-    local current_identity="$(git config user.identity)"
+    current_identity="$(git config user.identity)"
     if [ "$current_identity" == "$identity" ]
     then
       use_identity "$identity"
@@ -279,10 +289,11 @@ define_gpg () {
 }
 
 define_ssh () {
+  local identity sshkey sshkeyverbosity name current_identity
   local identity="$1"
   local sshkey="$2"
   local sshkeyverbosity="$3"
-  local name="$(lookup "$identity" name)"
+  name="$(lookup "$identity" name)"
 
   if [ -n "$name" ];
   then
@@ -294,7 +305,7 @@ define_ssh () {
       git config --global identity."$identity".sshkeyverbosity "$sshkeyverbosity"
     fi
 
-    local current_identity="$(git config user.identity)"
+    current_identity="$(git config user.identity)"
     if [ "$current_identity" == "$identity" ]
     then
       use_identity "$identity"

--- a/git-identity.bash-completion
+++ b/git-identity.bash-completion
@@ -1,4 +1,5 @@
 # vim: ft=sh:
+# shellcheck disable=SC2154
 _git_identity () {
 	# Needs the bash-completion for git proper
 	[ -n "$__git_whitespacelist" ] || return;
@@ -7,7 +8,7 @@ _git_identity () {
 	# git identity -h | tr '|' '\n'|grep -oE '\-.+'|cut -f1 -d']' |tr '\n' ' '
 	# The grep regex is a bit hack-y, but this is just over-optimizing anyway
 	# Whenever you add more commands just come add them here
-	local commands="-d --define --define-gpg -r --remove -l --list -R --list-raw -p --print -s --get-settings --define-ssh -u --update -h  -c --get-shell-command"
+	local commands="-d --define --define-gpg --define-ssh -p --print -s --get-settings -r --remove -l --list -R --list-raw -u --update -h -c --get-shell-command"
 
 	case "$cur" in
 		-*)

--- a/git-identity.zsh-completion
+++ b/git-identity.zsh-completion
@@ -3,16 +3,16 @@ local -a options identities
 identities=( $(git identity --list-raw) )
 options=(
 '-h:Show help'
-{-l,--list}':List all identities'
-{-R,--list-raw}':List only the names of all identities'
 {-d,--define}':Define a new identity'
 {--define-gpg}':Assign a GPG key with an identity'
-{-r,--remove}':Remove an identity'
+{--define-ssh}':Add a ssh key for the identity'
 {-p,--print}':Print an identity'
 {-s,--get-settings}':Print current local settings'
+{-r,--remove}':Remove an identity'
+{-l,--list}':List all identities'
+{-R,--list-raw}':List only the names of all identities'
 {-u,--update}':Update local settings based on the current identity'
 {-c,--get-shell-command}':Get GIT_SSH_COMMAND for an identiy or current identity'
-{--define-ssh}':Add a ssh key for the identity'
 )
 
 if (( CURRENT < 3 )); then


### PR DESCRIPTION
If you run the script through shellcheck, there are some warnings that might be worth to fix.

https://www.shellcheck.net/

- Fix all shellcheck warnings/errors
- harmonises the tab/spaces mixup, setting an indentation of 2 spaces everywhere.
- Order the options the same in the help strings and code