### PR TITLE
Fix test in function define_gpg

### DIFF
--- a/git-identity
+++ b/git-identity
@@ -266,7 +266,7 @@ define_gpg () {
     echo "Added GPG key $gpgkey to $(format_identity "$identity")"
   
     local current_identity="$(git config user.identity)"
-    if [ "$current_identity" == "$identity"]
+    if [ "$current_identity" == "$identity" ]
     then 
       use_identity "$identity"
     fi


### PR DESCRIPTION
Fix shell syntax error that was preventing for defining GPG key for some existing identity.