### PR TITLE
Sign tags too

### DIFF
--- a/git-identity
+++ b/git-identity
@@ -232,7 +232,7 @@ print_current_identity () {
 }
 
 get_current_settings () {
-  git config --local --get-regexp '^(user\.|commit\.gpgsign|tag\.gpgsign|core.ssh[cC]ommand)' | sort -u
+  git config --local --get-regexp '^(user\.|(commit|tag)\.gpgsign|core.ssh[cC]ommand)' | sort -u
 }
 
 # TODO: Make this interactive, at least for the code name/email

--- a/git-identity
+++ b/git-identity
@@ -147,9 +147,11 @@ use_identity () {
     then
       git config user.signingkey "$gpgkey"
       git config commit.gpgsign true
+      git config tag.gpgsign true
     else
       git config --unset user.signingkey
       git config --unset commit.gpgsign
+      git config --unset tag.gpgsign
     fi
 
     # Enable or disable SSH key usage
@@ -230,7 +232,7 @@ print_current_identity () {
 }
 
 get_current_settings () {
-  git config --local --get-regexp '^(user\.|commit\.gpgsign|core.ssh[cC]ommand)' | sort -u
+  git config --local --get-regexp '^(user\.|commit\.gpgsign|tag\.gpgsign|core.ssh[cC]ommand)' | sort -u
 }
 
 # TODO: Make this interactive, at least for the code name/email


### PR DESCRIPTION
Besides `commit.gpgSign`, there's also `tag.gpgSign`.

There's even `push.gpgSign`, but this is more obscure and produces a warning message on every push.